### PR TITLE
Update scripts to use 'docker compose' command

### DIFF
--- a/react-design-system-example/dev-env/rm-env.sh
+++ b/react-design-system-example/dev-env/rm-env.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-docker-compose -f "./docker-compose-dev.yml" down
+docker compose -f "./docker-compose-dev.yml" down
 rm -rf ./docker-dev-volumes

--- a/react-design-system-example/dev-env/run-env.sh
+++ b/react-design-system-example/dev-env/run-env.sh
@@ -14,4 +14,4 @@ echo "INFO - Removing current environment if exists..."
 ./rm-env.sh
 
 echo "INFO - Running docker containers..."
-docker-compose -f "./docker-compose-dev.yml" up -d --build
+docker compose -f "./docker-compose-dev.yml" up -d --build


### PR DESCRIPTION
In the latest versions of docker, docker-compose with the dash has been removed and is no longer working. 

https://docs.docker.com/compose/releases/migrate/#:~:text=From%20July%202023%20Compose%20V1,supported%20versions%20of%20Docker%20Desktop.

This pr just changes to the recommended "docker compose" (with the space).